### PR TITLE
Full test suite now working

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ deb_dist/*
 *.pyc
 .tox
 .eggs
+.python-version
+.cache

--- a/README.rst
+++ b/README.rst
@@ -71,37 +71,6 @@ If you are running zsh, execute the following command to enable autocomplete:
 
     autoload bashcompinit && autoload compinit && bashcompinit && compinit && eval "$(register-python-argcomplete conduct)"
 
-Running tests
-~~~~~~~~~~~~~
-
-Execute the following command to run unit tests for the current version of python3:
-
-.. code:: bash
-
-    python3 -m unittest
-
-Execute the following command to run all defined tests:
-
-.. code:: bash
-
-    python3 setup.py test
-
-To run only a specific test case in a test suite:
-
-.. code:: bash
-
-    python3 setup.py test -a "-- -s conductr_cli.test.test_conduct_unload:TestConductUnloadCommand.test_failure_invalid_address"
-
-Releasing
-~~~~~~~~~
-
-CLI releases can be performed completely from the GitHub project page. Follow these steps to cut a release:
-
-1. Edit `conductr_cli/__init__.py`_ file to contain the version to be released.
-2. Create a new release in GitHub `releases page`_.
-
-After CI build is finished for the tagged commit, new version will automatically be deployed to PyPi repository.
-
 CLI Usage
 ~~~~~~~~~
 
@@ -195,8 +164,40 @@ In both cases the source files are zipped and a SHA256 digest of the archive is 
 
 For pointers on command usage run ``shazar -h``.
 
-Information for developers
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+Developers
+~~~~~~~~~~
+
+For OS X, you should ensure firstly that you have the latest Xcode command line tools installed. 
+
+For all OS environments, pyenv is used to support multiple installations of python during testing. Refer to https://github.com/yyuu/pyenv for information on how to install pyenv. With pyenv installed you can do things like ``pyenv local 3.4.3`` or ``pyenv local system``.
+
+Then for OS X, install python 3.2 and 3.4:
+
+.. code:: bash
+
+  CFLAGS="-I$(brew --prefix openssl)/include" \
+  LDFLAGS="-L$(brew --prefix openssl)/lib" \
+  pyenv install -v 3.2.6
+  
+  CFLAGS="-I$(brew --prefix openssl)/include" \
+  LDFLAGS="-L$(brew --prefix openssl)/lib" \
+  pyenv install -v 3.4.3
+
+For others this is easier:
+
+.. code:: bash
+
+  pyenv install -v 3.2.6
+  pyenv install -v 3.4.3
+
+Make sure to install the necessary dependencies for each environment:
+
+.. code:: bash
+  
+  pip install -e .
+  
+Running
+^^^^^^^
 
 If you want to run ``conduct`` or ``sandbox`` locally, i.e. without installation, ``cd`` into the project directory and execute:
 
@@ -205,17 +206,34 @@ If you want to run ``conduct`` or ``sandbox`` locally, i.e. without installation
     python3 -m conductr_cli.conduct
     python3 -m conductr_cli.sandbox
 
-Make sure to install the necessary dependencies:
+Tests
+^^^^^
+
+Execute the following command to run unit tests for the current version of python3:
 
 .. code:: bash
 
-    pip install -e .
+    python3 -m unittest
 
-.. |Build Status| image:: https://travis-ci.org/typesafehub/conductr-cli.png
-    :target: https://travis-ci.org/typesafehub/conductr-cli
-    :alt: Build Status
-.. |Latest Version| image:: https://pypip.in/version/conductr-cli/badge.svg?style=flat
-    :target: https://pypi.python.org/pypi/conductr-cli/
-    :alt: Latest Version
-.. _releases page: https://github.com/typesafehub/conductr-cli/releases/new
-.. _conductr_cli/__init__.py: https://github.com/typesafehub/conductr-cli/blob/master/conductr_cli/__init__.py
+Execute the following command to run all defined tests:
+
+.. code:: bash
+
+    pyenv local system 3.26 3.4.3
+    python3 setup.py test
+
+To run only a specific test case in a test suite:
+
+.. code:: bash
+
+    python3 setup.py test -a "-- -s conductr_cli.test.test_conduct_unload:TestConductUnloadCommand.test_failure_invalid_address"
+
+Releasing
+^^^^^^^^^
+
+CLI releases can be performed completely from the GitHub project page. Follow these steps to cut a release:
+
+1. Edit `conductr_cli/__init__.py`_ file to contain the version to be released.
+2. Create a new release in GitHub `releases page`_.
+
+After CI build is finished for the tagged commit, new version will automatically be deployed to PyPi repository.

--- a/conductr_cli/conduct_info.py
+++ b/conductr_cli/conduct_info.py
@@ -24,7 +24,7 @@ def info(args):
             'starting': sum([not execution['isStarted'] for execution in bundle['bundleExecutions']]),
             'executions': sum([execution['isStarted'] for execution in bundle['bundleExecutions']])
         } for bundle in json.loads(response.text)
-        ]
+    ]
     data.insert(0, {'id': 'ID', 'name': 'NAME', 'replications': '#REP', 'starting': '#STR', 'executions': '#RUN'})
 
     padding = 2

--- a/conductr_cli/sandbox.py
+++ b/conductr_cli/sandbox.py
@@ -69,7 +69,7 @@ def build_parser():
                             action='append',
                             default=[],
                             help='Features to be enabled.\n'
-                                 'Available features: '+', '.join(features),
+                                 'Available features: ' + ', '.join(features),
                             choices=features,
                             metavar='')
     run_parser.set_defaults(func=sandbox_run.run)

--- a/conductr_cli/sandbox_stop.py
+++ b/conductr_cli/sandbox_stop.py
@@ -7,5 +7,5 @@ def stop(args):
 
     running_containers = sandbox_common.resolve_running_docker_containers()
     if running_containers:
-        print("Stopping ConductR..")
+        print('Stopping ConductR..')
         terminal.docker_rm(running_containers)

--- a/conductr_cli/test/conduct_load_test_base.py
+++ b/conductr_cli/test/conduct_load_test_base.py
@@ -21,6 +21,7 @@ class ConductLoadTestBase(CliTestCase):
 
     def __init__(self, method_name):
         super().__init__(method_name)
+
         self.bundle_file = None
         self.default_args = {}
         self.default_files = None
@@ -51,9 +52,9 @@ class ConductLoadTestBase(CliTestCase):
         open_mock = MagicMock(return_value=1)
 
         with patch('conductr_cli.conduct_load.urlretrieve', urlretrieve_mock), \
-             patch('requests.post', http_method), \
-             patch('sys.stdout', stdout), \
-             patch('builtins.open', open_mock):
+                patch('requests.post', http_method), \
+                patch('sys.stdout', stdout), \
+                patch('builtins.open', open_mock):
             conduct_load.load(MagicMock(**self.default_args))
 
         open_mock.assert_called_with(self.bundle_file, 'rb')
@@ -68,9 +69,9 @@ class ConductLoadTestBase(CliTestCase):
         open_mock = MagicMock(return_value=1)
 
         with patch('conductr_cli.conduct_load.urlretrieve', urlretrieve_mock), \
-             patch('requests.post', http_method), \
-             patch('sys.stdout', stdout), \
-             patch('builtins.open', open_mock):
+                patch('requests.post', http_method), \
+                patch('sys.stdout', stdout), \
+                patch('builtins.open', open_mock):
             args = self.default_args.copy()
             args.update({'verbose': True})
             conduct_load.load(MagicMock(**args))
@@ -87,9 +88,9 @@ class ConductLoadTestBase(CliTestCase):
         open_mock = MagicMock(return_value=1)
 
         with patch('conductr_cli.conduct_load.urlretrieve', urlretrieve_mock), \
-             patch('requests.post', http_method), \
-             patch('sys.stdout', stdout), \
-             patch('builtins.open', open_mock):
+                patch('requests.post', http_method), \
+                patch('sys.stdout', stdout), \
+                patch('builtins.open', open_mock):
             args = self.default_args.copy()
             args.update({'long_ids': True})
             conduct_load.load(MagicMock(**args))
@@ -107,9 +108,9 @@ class ConductLoadTestBase(CliTestCase):
 
         cli_parameters = ' --ip 127.0.1.1 --port 9006'
         with patch('conductr_cli.conduct_load.urlretrieve', urlretrieve_mock), \
-             patch('requests.post', http_method), \
-             patch('sys.stdout', stdout), \
-             patch('builtins.open', open_mock):
+                patch('requests.post', http_method), \
+                patch('sys.stdout', stdout), \
+                patch('builtins.open', open_mock):
             args = self.default_args.copy()
             args.update({'cli_parameters': cli_parameters})
             conduct_load.load(MagicMock(**args))
@@ -133,9 +134,9 @@ class ConductLoadTestBase(CliTestCase):
         open_mock = MagicMock(return_value=1)
 
         with patch('conductr_cli.conduct_load.urlretrieve', urlretrieve_mock), \
-             patch('requests.post', http_method), \
-             patch('sys.stdout', stdout), \
-             patch('builtins.open', open_mock):
+                patch('requests.post', http_method), \
+                patch('sys.stdout', stdout), \
+                patch('builtins.open', open_mock):
             args = self.default_args.copy()
             args.update({'configuration': config_file})
             conduct_load.load(MagicMock(**args))
@@ -159,9 +160,9 @@ class ConductLoadTestBase(CliTestCase):
         open_mock = MagicMock(return_value=1)
 
         with patch('conductr_cli.conduct_load.urlretrieve', urlretrieve_mock), \
-             patch('requests.post', http_method), \
-             patch('sys.stderr', stderr), \
-             patch('builtins.open', open_mock):
+                patch('requests.post', http_method), \
+                patch('sys.stderr', stderr), \
+                patch('builtins.open', open_mock):
             conduct_load.load(MagicMock(**self.default_args))
 
         open_mock.assert_called_with(self.bundle_file, 'rb')
@@ -179,9 +180,9 @@ class ConductLoadTestBase(CliTestCase):
         open_mock = MagicMock(return_value=1)
 
         with patch('conductr_cli.conduct_load.urlretrieve', urlretrieve_mock), \
-             patch('requests.post', http_method), \
-             patch('sys.stderr', stderr), \
-             patch('builtins.open', open_mock):
+                patch('requests.post', http_method), \
+                patch('sys.stderr', stderr), \
+                patch('builtins.open', open_mock):
             conduct_load.load(MagicMock(**self.default_args))
 
         open_mock.assert_called_with(self.bundle_file, 'rb')

--- a/conductr_cli/test/conduct_run_test_base.py
+++ b/conductr_cli/test/conduct_run_test_base.py
@@ -11,6 +11,7 @@ class ConductRunTestBase(CliTestCase):
 
     def __init__(self, method_name):
         super().__init__(method_name)
+
         self.default_args = {}
         self.default_url = None
         self.output_template = None

--- a/conductr_cli/test/test_conduct.py
+++ b/conductr_cli/test/test_conduct.py
@@ -89,7 +89,7 @@ class TestConduct(TestCase):
         self.assertEqual(args.bundle, 'path-to-bundle')
 
     def test_get_cli_parameters(self):
-        host.resolve_default_ip = lambda: "127.0.0.1"
+        host.resolve_default_ip = lambda: '127.0.0.1'
 
         args = Namespace(ip=None, port=9005, api_version='1.0')
         self.assertEqual(get_cli_parameters(args), ' --ip 127.0.0.1')

--- a/conductr_cli/test/test_conduct_load_v1_0.py
+++ b/conductr_cli/test/test_conduct_load_v1_0.py
@@ -59,40 +59,40 @@ class TestConductLoadCommand(ConductLoadTestBase):
 
     def test_success_verbose(self):
         self.base_test_success_verbose()
-        
+
     def test_success_long_ids(self):
         self.base_test_success_long_ids()
-        
+
     def test_success_custom_ip_port(self):
         self.base_test_success_custom_ip_port()
-        
+
     def test_success_with_configuration(self):
         self.base_test_success_with_configuration()
-        
+
     def test_failure(self):
         self.base_test_failure()
-        
+
     def test_failure_invalid_address(self):
         self.base_test_failure_invalid_address()
-        
+
     def test_failure_no_nr_of_cpus(self):
         self.base_test_failure_no_nr_of_cpus()
-        
+
     def test_failure_no_memory(self):
         self.base_test_failure_no_memory()
-        
+
     def test_failure_no_disk_space(self):
         self.base_test_failure_no_disk_space()
-        
+
     def test_failure_no_roles(self):
         self.base_test_failure_no_roles()
-        
+
     def test_failure_roles_not_a_list(self):
         self.base_test_failure_roles_not_a_list()
-        
+
     def test_failure_no_bundle(self):
         self.base_test_failure_no_bundle()
-        
+
     def test_failure_no_configuration(self):
         self.base_test_failure_no_configuration()
 

--- a/conductr_cli/test/test_conduct_load_v1_1.py
+++ b/conductr_cli/test/test_conduct_load_v1_1.py
@@ -1,6 +1,5 @@
 from conductr_cli.test.cli_test_case import create_temp_bundle, strip_margin
 from conductr_cli.test.conduct_load_test_base import ConductLoadTestBase
-import shutil
 
 
 class TestConductLoadCommand(ConductLoadTestBase):
@@ -100,5 +99,3 @@ class TestConductLoadCommand(ConductLoadTestBase):
 
     def test_failure_no_configuration(self):
         self.base_test_failure_no_configuration()
-
-

--- a/conductr_cli/test/test_conduct_logs.py
+++ b/conductr_cli/test/test_conduct_logs.py
@@ -1,4 +1,3 @@
-from unittest import TestCase
 from conductr_cli.test.cli_test_case import CliTestCase, strip_margin
 from conductr_cli import conduct_logs
 

--- a/conductr_cli/test/test_conduct_run_v1_0.py
+++ b/conductr_cli/test/test_conduct_run_v1_0.py
@@ -1,4 +1,4 @@
-from conductr_cli.test.cli_test_case import CliTestCase, strip_margin
+from conductr_cli.test.cli_test_case import strip_margin
 from conductr_cli.test.conduct_run_test_base import ConductRunTestBase
 from conductr_cli import conduct_run
 

--- a/conductr_cli/validation.py
+++ b/conductr_cli/validation.py
@@ -142,7 +142,7 @@ def handle_docker_errors(func):
         env_lines = []
         try:
             env_lines = terminal.docker_machine_env('default')
-            print("Retrieved docker environment variables with `docker-machine env default`")
+            print('Retrieved docker environment variables with `docker-machine env default`')
         except FileNotFoundError:
             try:
                 env_lines = terminal.boot2docker_shellinit()
@@ -151,13 +151,16 @@ def handle_docker_errors(func):
             except FileNotFoundError:
                 return []
         return [resolve_env(line) for line in env_lines if line.startswith('export')]
+
     def resolve_env(line):
         key = line.partition(' ')[-1].partition('=')[0]
         value = line.partition(' ')[-1].partition('=')[2].strip('"')
         return key, value
+
     def set_env(key, value):
         print('Set environment variable: {}="{}"'.format(key, value))
         os.environ[key] = value
+
     def handler(*args, **kwargs):
         try:
             return func(*args, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -24,10 +24,10 @@ class Tox(test):
     user_options = [('tox-args=', 'a', 'Arguments to pass to tox')]
 
     def __init__(self, dist, **kw):
-        super().__init__(dist, **kw)
         self.test_suite = True
         self.test_args = []
         self.tox_args = None
+        super().__init__(dist, **kw)
 
     def initialize_options(self):
         test.initialize_options(self)

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 envlist = py32, py34, flake8
 
 [testenv]
-deps = nose
-commands = nosetests -v {posargs}
+deps = pytest
+commands = py.test
 
 [testenv:flake8]
 deps =


### PR DESCRIPTION
Tox is now working locally for me on OS X. I've updated the README accordingly.

Also fixed up some PEP 8 failures that were picked up by running the flake8 tests as part of the full suite of tests.

Changed from nose to pytest given that nose picked up the super classes for testing undesirably.

All tests should now work on CI.
